### PR TITLE
fix: adding dependencies to angular-devkit in the nx-adsp package.

### DIFF
--- a/packages/nx-adsp/package.json
+++ b/packages/nx-adsp/package.json
@@ -9,5 +9,9 @@
     "@abgov/nx-oc": "^1.0.0",
     "@nrwl/express": "~11.5.2",
     "@nrwl/react": "~11.5.2"
+  },
+  "dependencies": {
+    "@angular-devkit/core": "~11.2.0",
+    "@angular-devkit/schematics": "~11.2.0"
   }
 }


### PR DESCRIPTION
This was working indirectly via peer dependency (@nrwl/express), but is also required for the react generator and the peer dep @nrwl/react does not include these dependencies.