### PR TITLE
fix(nx-adsp): changing webpack dev server proxy conf to start with localhost

### DIFF
--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -97,7 +97,7 @@ describe('React App Generator', () => {
     const proxyConf = JSON.parse(
       host.read('apps/test/proxy.conf.json').toString()
     );
-    expect(proxyConf['/test/'].target).toBe('http://test-service:3333');
+    expect(proxyConf['/test/'].target).toBe('http://localhost:3333');
     expect(proxyConf['/test/'].pathRewrite['^/test/']).toBe('/api/');
     
     done();

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -65,9 +65,9 @@ function addFiles(host: Tree, options: NormalizedSchema) {
         const upstreamUrl = new URL(nginxProxy.proxyPass);
         
         const proxy = {
-          target: `${upstreamUrl.protocol}//${upstreamUrl.hostname}${upstreamUrl.port ? ':' + upstreamUrl.port : ''}`,
+          target: `${upstreamUrl.protocol}//localhost${upstreamUrl.port ? ':' + upstreamUrl.port : ''}`,
           secure: upstreamUrl.protocol === 'https:',
-          changeOrigin: true,
+          changeOrigin: false,
           pathRewrite: {}
         }
 
@@ -130,8 +130,6 @@ export default async function (host: Tree, options: Schema) {
   const addedProxy = addFiles(host, normalizedOptions);
   removeFiles(host, normalizedOptions);
 
-  await formatFiles(host);
-
   const layout = getWorkspaceLayout(host);
 
   const config = readProjectConfiguration(host, options.name);
@@ -158,6 +156,8 @@ export default async function (host: Tree, options: Schema) {
   }
 
   updateProjectConfiguration(host, options.name, config);
+
+  await formatFiles(host);
 
   if (hasDependency(host, '@abgov/nx-oc')) {
     const { deploymentGenerator } = await import(`${'@abgov/nx-oc'}`);


### PR DESCRIPTION
Typical scenario is local dev of both frontend and backend, so localhost should be more useful default. Also moving formatFiles task after project configuration update, so that workspace.json is updated.