### PR TITLE
fix: Documenting limitations with channels, and removing use of non-prerelease channels in the generated config.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx nx affected --target release --base=origin/${{ github.base_ref }}
+        run: npx nx affected --target release --base=origin/${{ github.base_ref }} --dryRun

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,8 +36,3 @@ jobs:
         run: npm run affected:test -- --base=origin/${{ github.base_ref }}
       - name: Build
         run: npm run affected:build -- --base=origin/${{ github.base_ref }}
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx nx affected --target release --base=origin/${{ github.base_ref }} --dryRun

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - main
-      - next
       - beta
 
   # Allows you to run this workflow manually from the Actions tab
@@ -37,3 +36,8 @@ jobs:
         run: npm run affected:test -- --base=origin/${{ github.base_ref }}
       - name: Build
         run: npm run affected:build -- --base=origin/${{ github.base_ref }}
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx nx affected --target release --base=origin/${{ github.base_ref }}

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - next
       - beta
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,9 +2,7 @@
   "repositoryUrl": "git@github.com:abgov/nx-tools.git",
   "branches": [
     "+([0-9])?(.{+([0-9]),x}).x", 
-    "main", 
-    "next", 
-    "next-major", 
+    "main",
     {"name": "beta", "prerelease": true}, 
     {"name": "alpha", "prerelease": true}
   ]

--- a/packages/nx-release/README.md
+++ b/packages/nx-release/README.md
@@ -10,10 +10,17 @@ There are multiple challenges with using semantic release in a monorepo:
 2. Each project should be evaluated based on only commits related to it.
 3. Interdependencies between projects need to be handled.
 4. Interdependencies between publishable/releasable projects require coordination of releases.
+5. Channel (next-major, next, latest) information is stored in a git note on a semantic-release ref and does not distinguished between tags (and consequently projects).
 
-For 1, 2, and 3 in part this project uses the approach from [semantic-release-monorepo](https://github.com/pmowrer/semantic-release-monorepo) along with Nx capabilities: 
+For (1), (2), and (3) in part this project uses the approach from [semantic-release-monorepo](https://github.com/pmowrer/semantic-release-monorepo) along with Nx capabilities: 
 - Each project uses a distinct `tagFormat`; 
 - A custom plugin wraps default plugins for `analyzeCommits` and `generateNotes` and filters for only relevant commits;
 - Nx `dep-graph` is used to determine dependency paths that should also be included.
 
-4 is not currently handled, but a solution leveraging Nx capabilities is the general direction. For example, Nx supports ordered execution of tasks based on 'affected'.
+(4) is not currently handled, but a solution leveraging Nx capabilities is the general direction. For example, Nx supports ordered execution of tasks based on 'affected'.
+
+
+
+**KNOWN ISSUE** (5) from above is not handled, and non-prerelease channel upgrades will result in only the first project being upgraded when release tags from multiple projects are on the same commit. 
+
+In Semantic Release the channel upgrade is done separately from the next version analysis and there are no extension hooks to modify the behaviour. Prerelease channels with a distinct version format (e.g. 1.0.0-beta.x) are excluded from that process and appear to work.

--- a/packages/nx-release/src/generators/lib/root-files/.releaserc.json__tmpl__
+++ b/packages/nx-release/src/generators/lib/root-files/.releaserc.json__tmpl__
@@ -2,8 +2,6 @@
   "branches": [
     "+([0-9])?(.{+([0-9]),x}).x", 
     "main", 
-    "next", 
-    "next-major", 
     {"name": "beta", "prerelease": true}, 
     {"name": "alpha", "prerelease": true}
   ]

--- a/packages/nx-release/src/release-plugin/git-utils.spec.ts
+++ b/packages/nx-release/src/release-plugin/git-utils.spec.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, spawn } from 'child_process';
 import { ReadableStreamBuffer } from 'stream-buffers';
 import { mocked } from 'ts-jest/utils'
-import { getMergeCommitHashes, getPathCommitHashes } from './git-utils';
+import { getPathCommitHashes } from './git-utils';
 
 jest.mock('child_process');
 const mockedSpawn = mocked(spawn);
@@ -33,29 +33,6 @@ describe('git-utils', () => {
       expect(commits[1]).toBe('test2');
       expect(mockedSpawn.mock.calls.length).toBe(1);
   
-      done();
-    });
-  });
-
-  describe('getMergeCommitHashes', () => {
-
-    it('can get commits', async (done) => {
-
-      const stream = new ReadableStreamBuffer();
-      stream.put('test1\ntest2\n');
-      stream.stop();
-      
-      mockedSpawn.mockReturnValue({ stdout: stream } as unknown as ChildProcess)
-      const commits = await getMergeCommitHashes(
-        '',
-        'HEAD'
-      );
-
-      expect(commits.length).toBe(2);
-      expect(commits[0]).toBe('test1');
-      expect(commits[1]).toBe('test2');
-      expect(mockedSpawn.mock.calls.length).toBe(1);
-
       done();
     });
   });

--- a/packages/nx-release/src/release-plugin/git-utils.ts
+++ b/packages/nx-release/src/release-plugin/git-utils.ts
@@ -30,21 +30,3 @@ export async function getPathCommitHashes(
 
   return projectCommits[project];
 }
-
-export async function getMergeCommitHashes(
-  from: string,
-  to = 'HEAD'
-) {
-
-  const commits = await array<string>(spawn(
-    'git', 
-    [
-      'log', 
-      '--format=%H', 
-      '--merges',
-      `${from ? `${from}..` : ''}${to}`, 
-    ]
-  ).stdout.pipe(split()));
-
-  return commits;
-}

--- a/packages/nx-release/src/release-plugin/wrap-plugin.spec.ts
+++ b/packages/nx-release/src/release-plugin/wrap-plugin.spec.ts
@@ -2,19 +2,17 @@ import { Commit } from 'semantic-release';
 import { mocked } from 'ts-jest/utils'
 import { wrapPlugin } from './wrap-plugin';
 import { getProjectChangePaths } from './nx-util';
-import { getMergeCommitHashes, getPathCommitHashes } from './git-utils';
+import { getPathCommitHashes } from './git-utils';
 
 jest.mock('./nx-util');
 const mockedGetProjectChangePaths = mocked(getProjectChangePaths);
 jest.mock('./git-utils');
-const mockedGetMergeCommitHashes = mocked(getMergeCommitHashes);
 const mockedGetPathCommitHashes = mocked(getPathCommitHashes);
 
 describe('wrapPlugin', () => {
 
   beforeEach(() => {
     mockedGetProjectChangePaths.mockReset();
-    mockedGetMergeCommitHashes.mockReset();
     mockedGetPathCommitHashes.mockReset();
   });
   
@@ -32,10 +30,6 @@ describe('wrapPlugin', () => {
     
     mockedGetProjectChangePaths.mockReturnValue(
       Promise.resolve(['test1'])
-    );
-
-    mockedGetMergeCommitHashes.mockReturnValue(
-      Promise.resolve([])
     );
     
     mockedGetPathCommitHashes.mockReturnValue(
@@ -65,52 +59,6 @@ describe('wrapPlugin', () => {
     expect(plugin.mock.calls[0][0].config).toBe('config');
     expect(plugin.mock.calls[0][1].commits.length).toBe(1);
     expect(plugin.mock.calls[0][1].commits[0].commit.long).toBe('test1');
-
-    done();
-  });
-
-  it('can include merge commits', async (done) => {
-    const plugin = jest.fn();
-    plugin.mockReturnValue('result');
-    jest.mock('./git-utils');
-    const wrapped = wrapPlugin(plugin);
-    
-    mockedGetProjectChangePaths.mockReturnValue(
-      Promise.resolve(['test1'])
-    );
-
-    mockedGetMergeCommitHashes.mockReturnValue(
-      Promise.resolve(['test2'])
-    );
-    
-    mockedGetPathCommitHashes.mockReturnValue(
-      Promise.resolve(['test1'])
-    );
-    
-    const logger = { 
-      log: jest.fn(),
-      error: jest.fn()
-    }
-
-    const result = await wrapped(
-      { project: 'test', config: 'config' }, 
-      {
-        commits: [
-          { commit: { long: 'test1', short: 'test1' } } as Commit,
-          { commit: { long: 'test2', short: 'test2' } } as Commit
-        ], 
-        logger, 
-        env: {}, 
-        cwd: ''
-      }
-    );
-
-    expect(result).toBe('result');
-    expect(plugin.mock.calls.length).toBe(1);
-    expect(plugin.mock.calls[0][0].config).toBe('config');
-    expect(plugin.mock.calls[0][1].commits.length).toBe(2);
-    expect(plugin.mock.calls[0][1].commits[0].commit.long).toBe('test1');
-    expect(plugin.mock.calls[0][1].commits[1].commit.long).toBe('test2');
 
     done();
   });

--- a/packages/nx-release/src/release-plugin/wrap-plugin.ts
+++ b/packages/nx-release/src/release-plugin/wrap-plugin.ts
@@ -1,5 +1,5 @@
 import { Context, PluginConfig, PluginFunction } from '@semantic-release/semantic-release';
-import { getMergeCommitHashes, getPathCommitHashes } from './git-utils';
+import { getPathCommitHashes } from './git-utils';
 import { getProjectChangePaths } from './nx-util';
 
 export interface WrappedPluginConfig extends PluginConfig {
@@ -24,13 +24,7 @@ export const wrapPlugin = (plugin: PluginFunction) => async (
     const from = context.lastRelease?.gitHead;
     const to = context.nextRelease?.gitHead;
 
-    // Include merge commits as well as commits impacting particular paths.
-    // Merge commit for channel upgrade (next -> main) is TREESAME, but has to be
-    // analyzed for add channel.
-    const hashes = [
-      ...await getMergeCommitHashes(from, to),
-      ...await getPathCommitHashes(project, paths, from, to)
-    ];
+    const hashes = await getPathCommitHashes(project, paths, from, to);
     
     filteredCommits = commits.filter(
       commit => {


### PR DESCRIPTION
Reverting most of the changes on commit filtering since the channel upgrade happens outside of the plugins and is unaffected by the filtering.