### PR TITLE
Feature - angular oc deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21359,6 +21359,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -29,14 +29,167 @@ describe('Deployment Generator', () => {
     });
 
     await generator(host, options);
-    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
-    expect(host.exists('.openshift/test/Dockerfile')).toBeTruthy();
     
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['apply-envs']).toBeTruthy();
     expect(config.targets['apply-envs'].executor).toBe('@abgov/nx-oc:apply');
     expect(config.targets['apply-envs'].options.ocProject).toContain('test-dev');
    
+    done();
+  });
+
+  it ('can generate deployment for react', async (done) => {
+    const host = createTreeWithEmptyWorkspace();
+    await pipeline(
+      host, 
+      { 
+        pipeline: 'test', 
+        infra: 'test-infra', 
+        envs: 'test-dev' 
+      }
+    );
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nrwl/web:build'
+        }
+      }
+    });
+
+    await generator(host, options);
+    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
+    expect(host.exists('.openshift/test/Dockerfile')).toBeTruthy();
+
+    const dockerfile = host.read('.openshift/test/Dockerfile').toString();
+    expect(dockerfile).toContain('nginx');
+   
+    done();
+  });
+
+  it ('can generate deployment for angular', async (done) => {
+    const host = createTreeWithEmptyWorkspace();
+    await pipeline(
+      host, 
+      { 
+        pipeline: 'test', 
+        infra: 'test-infra', 
+        envs: 'test-dev' 
+      }
+    );
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser'
+        }
+      }
+    });
+
+    await generator(host, options);
+    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
+    expect(host.exists('.openshift/test/Dockerfile')).toBeTruthy();
+
+    const dockerfile = host.read('.openshift/test/Dockerfile').toString();
+    expect(dockerfile).toContain('nginx');
+   
+    done();
+  });
+
+  it ('can generate deployment for express', async (done) => {
+    const host = createTreeWithEmptyWorkspace();
+    await pipeline(
+      host, 
+      { 
+        pipeline: 'test', 
+        infra: 'test-infra', 
+        envs: 'test-dev' 
+      }
+    );
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nrwl/node:build'
+        }
+      }
+    });
+
+    await generator(host, options);
+    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
+    expect(host.exists('.openshift/test/Dockerfile')).toBeTruthy();
+
+    const dockerfile = host.read('.openshift/test/Dockerfile').toString();
+    expect(dockerfile).toContain('node');
+   
+    done();
+  });
+
+  it ('can generate deployment for dotnet', async (done) => {
+    const host = createTreeWithEmptyWorkspace();
+    await pipeline(
+      host, 
+      { 
+        pipeline: 'test', 
+        infra: 'test-infra', 
+        envs: 'test-dev' 
+      }
+    );
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@abgov/nx-dotnet:build'
+        }
+      }
+    });
+
+    await generator(host, options);
+    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
+    expect(host.exists('.openshift/test/Dockerfile')).toBeTruthy();
+
+    const dockerfile = host.read('.openshift/test/Dockerfile').toString();
+    expect(dockerfile).toContain('dotnet');
+   
+    done();
+  });
+
+  it ('can skip unknown project type', async (done) => {
+    const host = createTreeWithEmptyWorkspace();
+    await pipeline(
+      host, 
+      { 
+        pipeline: 'test', 
+        infra: 'test-infra', 
+        envs: 'test-dev' 
+      }
+    );
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nrwl/not-real:build'
+        }
+      }
+    });
+
+    await generator(host, options);
+    expect(host.exists('.openshift/test/test.yml')).toBeFalsy();
+    expect(host.exists('.openshift/test/Dockerfile')).toBeFalsy();
+    
+    const config = readProjectConfiguration(host, 'test');
+    expect(config.targets['apply-envs']).toBeFalsy();
+    
     done();
   });
 });


### PR DESCRIPTION
Updates to nx-oc plugin to handle angular builder and use the frontend templates (nginx based container).

Handle unrecognized project (unknown builder value) by skipping generation instead od defaulting to dotnet.
