### PR TITLE
fix(nx-adsp): Fixed test and linter issues and some misc stuff

### DIFF
--- a/packages/nx-adsp/package.json
+++ b/packages/nx-adsp/package.json
@@ -11,7 +11,7 @@
   },
   "peerDependencies": {
     "@abgov/nx-dotnet": "^1.0.0",
-    "@abgov/nx-oc": "^1.4.0",
+    "@abgov/nx-oc": "^1.4.0-beta.0",
     "@nrwl/express": "^11.5.2",
     "@nrwl/react": "^11.5.2",
     "@nrwl/angular": "^11.5.2"

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -22,6 +22,7 @@ function normalizeOptions(
 ): NormalizedSchema {
   const projectName = names(options.name).fileName;
   const projectRoot = `${getWorkspaceLayout(host).appsDir}/${projectName}`;
+  const projectOrg = getWorkspaceLayout(host).npmScope;
   const openshiftDirectory = `.openshift/${projectName}`
 
   const adsp = getAdspConfiguration(host, options);
@@ -39,6 +40,7 @@ function normalizeOptions(
     projectName,
     projectRoot,
     openshiftDirectory,
+    projectOrg,
     adsp,
     nginxProxies
   };

--- a/packages/nx-adsp/src/generators/angular-app/files/src/app/app.component.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/src/app/app.component.spec.ts__tmpl__
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { AppComponent } from './app.component';
+import { AngularComponentsModule } from '@abgov/angular-components';
+
+describe('AppComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AppComponent],
+      imports: [AngularComponentsModule]
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+
+  it(`should have as title 'test-angular-app'`, () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.title).toEqual('test-angular-app');
+  });
+
+  it('should render title', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('h2').textContent).toContain(
+      'Welcome to test-angular-app!'
+    );
+  });
+});

--- a/packages/nx-adsp/src/generators/angular-app/files/src/app/app.component.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/src/app/app.component.ts__tmpl__
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: '<%= projectOrg %>-app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })

--- a/packages/nx-adsp/src/generators/angular-app/files/src/index.html__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/src/index.html__tmpl__
@@ -8,6 +8,6 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>
-    <app-root></app-root>
+    <<%= projectOrg %>-app-root></<%= projectOrg %>-app-root>
   </body>
 </html>

--- a/packages/nx-adsp/src/generators/angular-app/files/src/test-setup.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/src/test-setup.ts__tmpl__
@@ -1,0 +1,3 @@
+import 'jest-preset-angular';
+//https://github.com/thymikee/jest-preset-angular/issues/347
+import '@angular/localize/init';

--- a/packages/nx-adsp/src/generators/angular-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/angular-app/schema.d.ts
@@ -8,6 +8,7 @@ export interface AngularAppGeneratorSchema {
 export interface NormalizedSchema extends AngularAppGeneratorSchema {
   projectName: string;
   projectRoot: string;
+  projectOrg: string;
   openshiftDirectory: string;
   adsp: AdspConfiguration
   nginxProxies: NginxProxyConfiguration[];


### PR DESCRIPTION
* Tests - import UI components, import polyfill (fix required, see
  related note)
* Linter - linter expects tags to start with the folder name - generated
  a new variable for org folder name - folder name cannot contain
  numbers or it will fail
* Still had version conflict on npm install, fixed that