### PR TITLE
fix(nx-oc): Using service account group in the puller role binding instead of the specific puller account.

### DIFF
--- a/packages/nx-oc/src/generators/deployment/deployment.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.ts
@@ -24,7 +24,11 @@ function normalizeOptions(
   const result = host.read(infraManifestFile).toString();
   const { items } = yaml.parse(result);
   const ocInfraProject = items[0]?.metadata?.namespace || ''
-  const ocEnvProjects = items[0]?.subjects?.map(s => s.namespace);
+  
+  const SA_PREFIX = 'system:serviceaccounts:'
+  const ocEnvProjects = items[0]?.subjects?.filter(
+    (s) => s.kind === 'Group' && s.name.startsWith(SA_PREFIX)
+  ).map((s) => s.name.replace(SA_PREFIX, ''));
   
   // TODO: Find a better way to determine this.
   const config = readProjectConfiguration(host, projectName);

--- a/packages/nx-oc/src/generators/pipeline/files/environments.yml__tmpl__
+++ b/packages/nx-oc/src/generators/pipeline/files/environments.yml__tmpl__
@@ -12,9 +12,9 @@ items:
       name: 'system:image-puller'
     subjects:
 <% ocEnvProjects.forEach(function(ocEnvProject){ -%>
-      - kind: ServiceAccount
-        name: deployer
-        namespace: <%= ocEnvProject %>
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: 'system:serviceaccounts:<%= ocEnvProject %>'
 <% }); -%>
 <% ocEnvProjects.forEach(function(ocEnvProject){ -%>
   - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Updated deployment generator to parse the service account format for env projects.